### PR TITLE
Use HTTPS instead of HTTP in google font url

### DIFF
--- a/vendor/assets/stylesheets/rails_admin/themes/rst_theme/theming/layout.sass
+++ b/vendor/assets/stylesheets/rails_admin/themes/rst_theme/theming/layout.sass
@@ -1,4 +1,4 @@
-@import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700')
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700')
 
 body.rails_admin
   font-family: 'Source Sans Pro', sans-serif


### PR DESCRIPTION
There is an issue with access to Google Font from pages without SSL. So by default this theme should retrieve fonts using SSL connection.